### PR TITLE
Fix User entity ID generation and CORS property key structure

### DIFF
--- a/src/main/java/org/sfa/volunteer/model/User.java
+++ b/src/main/java/org/sfa/volunteer/model/User.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 public class User {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "user_id", nullable = false)
     private String id;
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,14 +1,15 @@
 cors:
-  allowed-origin: <application-url>
-  allowed-methods: GET, POST, PUT, DELETE, OPTIONS
-  allowed-headers: Authorization
-  allow-credentials: true
+  allowed:
+    origin: http://localhost:3000
+    methods: GET, POST, PUT, DELETE, OPTIONS
+    headers: Authorization
+    credentials: true
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/saayam
-    username: <username>
-    password: <password>
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/saayam}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:}
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
User entity declared `String id` with `GenerationType.IDENTITY`, which Postgres rejects (identity columns must be integer types). Switch to `GenerationType.UUID` so Hibernate generates a UUID string at insert time. This unblocks application context startup.

CORS keys in application.yaml were flattened with hyphens (`cors.allowed-origin`), but CorsConfiguration reads them with dots (`${cors.allowed.origin}`). `@Value` does not apply Spring's relaxed binding, so the placeholders never resolved and bean creation failed. Re-nest the keys to match. Also parameterize datasource credentials with `${ENV:default}` so contributors don't have to hand-edit the file.