### PR TITLE
Update notification APIs to support POST requests

### DIFF
--- a/src/main/java/org/sfa/volunteer/controller/VolunteerController.java
+++ b/src/main/java/org/sfa/volunteer/controller/VolunteerController.java
@@ -2,7 +2,9 @@ package org.sfa.volunteer.controller;
 import jakarta.validation.Valid;
 import org.sfa.volunteer.dto.common.SaayamResponse;
 import org.sfa.volunteer.dto.common.SaayamStatusCode;
+import org.sfa.volunteer.dto.request.NotificationRequest;
 import org.sfa.volunteer.dto.request.VolunteerRequest;
+import org.sfa.volunteer.dto.response.NotificationCountResponse;
 import org.sfa.volunteer.dto.response.NotificationPaginationResponse;
 import org.sfa.volunteer.dto.response.NotificationsResponse;
 import org.sfa.volunteer.dto.response.VolunteerResponse;
@@ -26,6 +28,9 @@ import java.time.LocalDateTime;
 @RestController
 @RequestMapping("/0.0.1/volunteers")
 public class VolunteerController {
+    private static final int DEFAULT_NOTIFICATION_PAGE = 0;
+    private static final int DEFAULT_NOTIFICATION_SIZE = 10;
+
     private final VolunteerService volunteerService;
     private final ResponseBuilder responseBuilder;
 
@@ -91,10 +96,16 @@ public class VolunteerController {
         return responseBuilder.buildSuccessResponse(SaayamStatusCode.SUCCESS, new Object[]{userId}, response);
     }
 
-    @GetMapping("/count/{userId}")
+    @PostMapping("/count/{userId}")
     public SaayamResponse<Long> getNotificationsCount(@PathVariable String userId) {
         Long notificationCount = volunteerService.getNotificationsCountAfterLastAccessed(userId);
         return responseBuilder.buildSuccessResponse(SaayamStatusCode.SUCCESS, notificationCount);
+    }
+
+    @PostMapping("/getNotificationsCount")
+    public SaayamResponse<NotificationCountResponse> getNotificationsCount(@Valid @RequestBody NotificationRequest request) {
+        Long notificationCount = volunteerService.getNotificationsCountAfterLastAccessed(request.userId());
+        return responseBuilder.buildSuccessResponse(SaayamStatusCode.SUCCESS, new NotificationCountResponse(notificationCount));
     }
 
     //    Need to test this
@@ -105,13 +116,32 @@ public class VolunteerController {
 //        return responseBuilder.buildSuccessResponse(SaayamStatusCode.SUCCESS, notificationsList);
 //    }
 
-    @GetMapping("/getNotifications/{userId}")
+    @PostMapping("/getNotifications/{userId}")
     public SaayamResponse<NotificationPaginationResponse<NotificationsResponse>> getAllNotifications(@PathVariable String userId, @RequestParam int page, @RequestParam int size, @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime refTime) throws Exception {
         try{
             NotificationPaginationResponse<NotificationsResponse> notificationsList = volunteerService.getNotificationsList(userId, page, size, refTime);
             return responseBuilder.buildSuccessResponse(SaayamStatusCode.SUCCESS, notificationsList);
         } catch (VolunteerException e){
             return  responseBuilder.buildErrorResponse(500, SaayamStatusCode.BAD_REQUEST, e.getMessage());
+        }
     }
-}
+
+    @PostMapping("/getNotificationsList")
+    public SaayamResponse<NotificationPaginationResponse<NotificationsResponse>> getAllNotifications(
+            @Valid @RequestBody NotificationRequest request,
+            @RequestParam(value = "page", required = false) Integer page,
+            @RequestParam(value = "size", required = false) Integer size,
+            @RequestParam(value = "clientRefTime", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime clientRefTime) throws Exception {
+        int pageNumber = request.page() != null ? request.page() : (page != null ? page : DEFAULT_NOTIFICATION_PAGE);
+        int pageSize = request.size() != null ? request.size() : (size != null ? size : DEFAULT_NOTIFICATION_SIZE);
+        LocalDateTime referenceTime = request.clientRefTime() != null ? request.clientRefTime() : clientRefTime;
+
+        try{
+            NotificationPaginationResponse<NotificationsResponse> notificationsList = volunteerService.getNotificationsList(request.userId(), pageNumber, pageSize, referenceTime);
+            return responseBuilder.buildSuccessResponse(SaayamStatusCode.SUCCESS, notificationsList);
+        } catch (VolunteerException e){
+            return  responseBuilder.buildErrorResponse(500, SaayamStatusCode.BAD_REQUEST, e.getMessage());
+        }
+    }
 }

--- a/src/main/java/org/sfa/volunteer/dto/request/NotificationRequest.java
+++ b/src/main/java/org/sfa/volunteer/dto/request/NotificationRequest.java
@@ -1,0 +1,12 @@
+package org.sfa.volunteer.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDateTime;
+
+public record NotificationRequest(
+        @NotBlank String userId,
+        Integer page,
+        Integer size,
+        LocalDateTime clientRefTime) {
+}

--- a/src/main/java/org/sfa/volunteer/handler/GetNotificationsCountHandler.java
+++ b/src/main/java/org/sfa/volunteer/handler/GetNotificationsCountHandler.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.sfa.volunteer.VolunteerApplication;
 import org.sfa.volunteer.dto.common.SaayamResponse;
 import org.sfa.volunteer.dto.common.SaayamStatusCode;
+import org.sfa.volunteer.dto.request.NotificationRequest;
 import org.sfa.volunteer.dto.response.NotificationCountResponse;
 import org.sfa.volunteer.service.VolunteerService;
 import org.sfa.volunteer.util.MessageSourceUtil;
@@ -40,11 +41,18 @@ public class GetNotificationsCountHandler implements RequestHandler<APIGatewayPr
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent requestEvent, Context context) {
         APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent();
         try{
-            String lang = requestEvent.getHeaders().getOrDefault("Accept-Language", "en");
+            String lang = Optional.ofNullable(requestEvent.getHeaders())
+                    .map(headers -> headers.getOrDefault("Accept-Language", "en"))
+                    .orElse("en");
             Locale locale = Locale.forLanguageTag(lang);
+            NotificationRequest bodyRequest = parseBodyRequest(requestEvent);
             String userId = Optional.ofNullable(requestEvent.getPathParameters())
                     .map(p -> p.get("userId"))
-                    .orElseThrow(() -> new RuntimeException("Missing path parameter 'userId'"));
+                    .filter(id -> !id.isBlank())
+                    .orElse(bodyRequest != null ? bodyRequest.userId() : null);
+            if (userId == null || userId.isBlank()) {
+                throw new RuntimeException("Missing userId");
+            }
 
             Long notificationsCount = volunteerService.getNotificationsCountAfterLastAccessed(userId);
             NotificationCountResponse notificationCountResponse = new NotificationCountResponse(notificationsCount);
@@ -75,5 +83,12 @@ public class GetNotificationsCountHandler implements RequestHandler<APIGatewayPr
 
 
         return response;
+    }
+
+    private NotificationRequest parseBodyRequest(APIGatewayProxyRequestEvent requestEvent) throws Exception {
+        if (requestEvent.getBody() == null || requestEvent.getBody().isBlank()) {
+            return null;
+        }
+        return objectMapper.readValue(requestEvent.getBody(), NotificationRequest.class);
     }
 }

--- a/src/main/java/org/sfa/volunteer/handler/GetNotificationsListHandler.java
+++ b/src/main/java/org/sfa/volunteer/handler/GetNotificationsListHandler.java
@@ -10,9 +10,9 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.sfa.volunteer.VolunteerApplication;
 import org.sfa.volunteer.dto.common.SaayamResponse;
 import org.sfa.volunteer.dto.common.SaayamStatusCode;
+import org.sfa.volunteer.dto.request.NotificationRequest;
 import org.sfa.volunteer.dto.response.NotificationPaginationResponse;
 import org.sfa.volunteer.dto.response.NotificationsResponse;
-import org.sfa.volunteer.dto.response.PaginationResponse;
 import org.sfa.volunteer.service.VolunteerService;
 import org.sfa.volunteer.util.MessageSourceUtil;
 import org.sfa.volunteer.util.ResponseBuilder;
@@ -26,6 +26,9 @@ import java.util.Optional;
 
 
 public class GetNotificationsListHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>  {
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 10;
+
     private static final VolunteerService volunteerService;
     private static final ResponseBuilder responseBuilder;
     private static final MessageSourceUtil messageSourceUtil;
@@ -45,30 +48,40 @@ public class GetNotificationsListHandler implements RequestHandler<APIGatewayPro
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent requestEvent, Context context) {
         APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent();
         try{
-            String lang = requestEvent.getHeaders().getOrDefault("Accept-Language", "en");
+            String lang = Optional.ofNullable(requestEvent.getHeaders())
+                    .map(headers -> headers.getOrDefault("Accept-Language", "en"))
+                    .orElse("en");
             Locale locale = Locale.forLanguageTag(lang);
 
             Map<String, String> queryStringParameters = requestEvent.getQueryStringParameters();
+            NotificationRequest bodyRequest = parseBodyRequest(requestEvent);
             String userId = Optional.ofNullable(requestEvent.getPathParameters())
                     .map(p -> p.get("userId"))
-                    .orElseThrow(() -> new RuntimeException("Missing path parameter 'userId'"));
-            Integer page = null;
-            Integer size = null;
-            LocalDateTime clientRefTime = null;
+                    .filter(id -> !id.isBlank())
+                    .orElse(bodyRequest != null ? bodyRequest.userId() : null);
+            if (userId == null || userId.isBlank()) {
+                throw new RuntimeException("Missing userId");
+            }
+
+            Integer page = bodyRequest != null ? bodyRequest.page() : null;
+            Integer size = bodyRequest != null ? bodyRequest.size() : null;
+            LocalDateTime clientRefTime = bodyRequest != null ? bodyRequest.clientRefTime() : null;
             if (queryStringParameters != null) {
-                if (queryStringParameters.containsKey("page")) {
+                if (page == null && queryStringParameters.containsKey("page")) {
                     page = Integer.parseInt(queryStringParameters.get("page"));
                 }
-                if (queryStringParameters.containsKey("size")) {
+                if (size == null && queryStringParameters.containsKey("size")) {
                     size = Integer.parseInt(queryStringParameters.get("size"));
                 }
-                if (queryStringParameters.containsKey("clientRefTime")) {
+                if (clientRefTime == null && queryStringParameters.containsKey("clientRefTime")) {
                     clientRefTime = LocalDateTime.parse(queryStringParameters.get("clientRefTime"));
                 }
 
 
             }
-            NotificationPaginationResponse<NotificationsResponse> paginationResponse = volunteerService.getNotificationsList(userId, page, size, clientRefTime);
+            int pageNumber = page != null ? page : DEFAULT_PAGE;
+            int pageSize = size != null ? size : DEFAULT_SIZE;
+            NotificationPaginationResponse<NotificationsResponse> paginationResponse = volunteerService.getNotificationsList(userId, pageNumber, pageSize, clientRefTime);
 
             SaayamResponse<NotificationPaginationResponse<NotificationsResponse>> successResponse = responseBuilder.buildSuccessResponse(
                     SaayamStatusCode.SUCCESS,
@@ -102,6 +115,13 @@ public class GetNotificationsListHandler implements RequestHandler<APIGatewayPro
 
 
 
+    }
+
+    private NotificationRequest parseBodyRequest(APIGatewayProxyRequestEvent requestEvent) throws Exception {
+        if (requestEvent.getBody() == null || requestEvent.getBody().isBlank()) {
+            return null;
+        }
+        return objectMapper.readValue(requestEvent.getBody(), NotificationRequest.class);
     }
 
 


### PR DESCRIPTION
Summary:
- Updated notification count and notification list APIs to support POST requests.
- Added request-body support for userId, page, size, and clientRefTime.
- Updated related Lambda handlers while keeping existing path/query parameter flow compatible.

Verification:
- Ran mvn clean compile successfully with Java 17.

Note:
- Targeting shreenidhiacharya_notifications_issue#85 because this work was based on that branch and keeps the PR diff limited to my changes.